### PR TITLE
fix tensorsplat example

### DIFF
--- a/R/tensorsplat.R
+++ b/R/tensorsplat.R
@@ -7,12 +7,12 @@
 #' @returns Anomalous observations
 #'
 #' @examples
-#' # We generate a series of networks and add an anomaly at 50th network.
+#' # We generate a series of networks and add an anomaly at 20th network.
 #' set.seed(1)
 #' networks <- list()
 #' p.or.m.seq <- rep(0.05, 50)
 #' p.or.m.seq[20] <- 0.2  # anomalous network at 20
-#' for(i in 1:100){
+#' for(i in 1:50){
 #'   gr <- igraph::erdos.renyi.game(100, p.or.m = p.or.m.seq[i])
 #'   networks[[i]] <- igraph::as_adjacency_matrix(gr)
 #' }


### PR DESCRIPTION
This example creates a 50-length list and tries to take indices up to 100, getting `NA` values which are invalid for `erdos.renyi.game()`. The next version of igraph will throw an error, causing tests for this package to fail.

As an additional note, `erdos.renyi.game()` is deprecated in favour of `sample_gnm()` and `sample_gnp()`. Consider using these. Most igraph functions with a `.` in their name should be considered deprecated. Look up the documentation of a function, and if the doc page gives you a different name, consider the name you looked up deprecated.