### PR TITLE
refactor: replace deprecated `igraph::erdos.renyi.game()` with `igraph::sample_gnp()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Anomaly detection in dynamic, temporal networks. The package
 License: GPL (>= 3)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Imports: 
     dplyr,
     fable,

--- a/R/anomaly_detection.R
+++ b/R/anomaly_detection.R
@@ -28,10 +28,10 @@
 #' # We generate a series of networks and add an anomaly at 50th network.
 #' set.seed(1)
 #' networks <- list()
-#' p.or.m.seq <- rep(0.1, 50)
-#' p.or.m.seq[20] <- 0.3  # anomalous network at 20
+#' p.seq <- rep(0.1, 50)
+#' p.seq[20] <- 0.3  # anomalous network at 20
 #' for(i in 1:50){
-#'   gr <- igraph::erdos.renyi.game(50, p.or.m = p.or.m.seq[i])
+#'   gr <- igraph::sample_gnp(50, p = p.seq[i])
 #'   networks[[i]] <- igraph::as_adjacency_matrix(gr)
 #' }
 #' anomalous_networks(networks, fast = TRUE)

--- a/R/features.R
+++ b/R/features.R
@@ -12,7 +12,7 @@
 #'
 #' @examples
 #' set.seed(1)
-#' gr <- igraph::erdos.renyi.game(100, 0.05)
+#' gr <- igraph::sample_gnp(100, 0.05)
 #' compute_features(gr)
 #'
 #'

--- a/R/laplacian_eigenvalue_method.R
+++ b/R/laplacian_eigenvalue_method.R
@@ -56,10 +56,10 @@ lad_scores <- function(context, win_width ){
 #' # We generate a series of networks and add an anomaly at 50th network.
 #' set.seed(1)
 #' networks <- list()
-#' p.or.m.seq <- rep(0.05, 50)
-#' p.or.m.seq[20] <- 0.2  # anomalous network at 20
+#' p.seq <- rep(0.05, 50)
+#' p.seq[20] <- 0.2  # anomalous network at 20
 #' for(i in 1:50){
-#'   gr <- igraph::erdos.renyi.game(100, p.or.m = p.or.m.seq[i])
+#'   gr <- igraph::sample_gnp(100, p = p.seq[i])
 #'   networks[[i]] <- igraph::as_adjacency_matrix(gr)
 #' }
 #' ladobj <- lad(networks, k = 6, short_win = 2, long_win = 4)

--- a/README.Rmd
+++ b/README.Rmd
@@ -40,10 +40,10 @@ library(oddnet)
 library(igraph)
 set.seed(1)
 networks <- list()
-p.or.m.seq <- rep(0.05, 100)
-p.or.m.seq[50] <- 0.2  # outlying network at 50
+p.seq <- rep(0.05, 100)
+p.seq[50] <- 0.2  # outlying network at 50
 for(i in 1:100){
- gr <- igraph::erdos.renyi.game(100, p.or.m = p.or.m.seq[i])
+ gr <- igraph::sample_gnp(100, p = p.seq[i])
  networks[[i]] <- igraph::as_adjacency_matrix(gr)
 }
 anom <- anomalous_networks(networks)

--- a/README.md
+++ b/README.md
@@ -39,13 +39,16 @@ library(igraph)
 #>     union
 set.seed(1)
 networks <- list()
-p.or.m.seq <- rep(0.05, 100)
-p.or.m.seq[50] <- 0.2  # outlying network at 50
+p.seq <- rep(0.05, 100)
+p.seq[50] <- 0.2  # outlying network at 50
 for(i in 1:100){
- gr <- igraph::erdos.renyi.game(100, p.or.m = p.or.m.seq[i])
+ gr <- igraph::sample_gnp(100, p = p.seq[i])
  networks[[i]] <- igraph::as_adjacency_matrix(gr)
 }
 anom <- anomalous_networks(networks)
+#> Registered S3 method overwritten by 'tsibble':
+#>   method               from 
+#>   as_tibble.grouped_df dplyr
 anom
 #> Leave-out-out KDE outliers using lookout algorithm
 #> 

--- a/man/anomalous_networks.Rd
+++ b/man/anomalous_networks.Rd
@@ -56,10 +56,10 @@ feature computation, scaling, robust PCA and anomaly detection procedures.   ADD
 # We generate a series of networks and add an anomaly at 50th network.
 set.seed(1)
 networks <- list()
-p.or.m.seq <- rep(0.1, 50)
-p.or.m.seq[20] <- 0.3  # anomalous network at 20
+p.seq <- rep(0.1, 50)
+p.seq[20] <- 0.3  # anomalous network at 20
 for(i in 1:50){
-  gr <- igraph::erdos.renyi.game(50, p.or.m = p.or.m.seq[i])
+  gr <- igraph::sample_gnp(50, p = p.seq[i])
   networks[[i]] <- igraph::as_adjacency_matrix(gr)
 }
 anomalous_networks(networks, fast = TRUE)

--- a/man/compute_features.Rd
+++ b/man/compute_features.Rd
@@ -24,7 +24,7 @@ This function computes features for each network using graph theoretic construct
 }
 \examples{
 set.seed(1)
-gr <- igraph::erdos.renyi.game(100, 0.05)
+gr <- igraph::sample_gnp(100, 0.05)
 compute_features(gr)
 
 

--- a/man/lad.Rd
+++ b/man/lad.Rd
@@ -33,10 +33,10 @@ and Reihaneh Rabbany from their KDD'20 paper Laplacian Change Point Detection fo
 # We generate a series of networks and add an anomaly at 50th network.
 set.seed(1)
 networks <- list()
-p.or.m.seq <- rep(0.05, 50)
-p.or.m.seq[20] <- 0.2  # anomalous network at 20
+p.seq <- rep(0.05, 50)
+p.seq[20] <- 0.2  # anomalous network at 20
 for(i in 1:50){
-  gr <- igraph::erdos.renyi.game(100, p.or.m = p.or.m.seq[i])
+  gr <- igraph::sample_gnp(100, p = p.seq[i])
   networks[[i]] <- igraph::as_adjacency_matrix(gr)
 }
 ladobj <- lad(networks, k = 6, short_win = 2, long_win = 4)

--- a/vignettes/oddnet.Rmd
+++ b/vignettes/oddnet.Rmd
@@ -25,10 +25,10 @@ We create a sequence of temporal networks based on the Erdos Renyi construction 
 ```{r readdata}
 set.seed(1)
 networks <- list()
-p.or.m.seq <- seq(from = 0.01, to = 0.2, length.out = 100)
-p.or.m.seq[50] <- p.or.m.seq[50] + 0.2  # anomalous network
+p.seq <- seq(from = 0.01, to = 0.2, length.out = 100)
+p.seq[50] <- p.seq[50] + 0.2  # anomalous network
  for(i in 1:100){
-  gr <- igraph::erdos.renyi.game(100, p.or.m = p.or.m.seq[i])
+  gr <- igraph::sample_gnp(100, p = p.seq[i])
   networks[[i]] <- igraph::as_adjacency_matrix(gr)
 }
 ```


### PR DESCRIPTION
:wave: @sevvandi!

The function is being soft-deprecated but we'll be moving towards hard-deprecation so I'm already making a PR.